### PR TITLE
feat: Implement linear and cosine beta schedules

### DIFF
--- a/DENOISING_DIFFUSION/src/models/noise_scheduler.py
+++ b/DENOISING_DIFFUSION/src/models/noise_scheduler.py
@@ -1,0 +1,155 @@
+"""Noise scheduler for the forward and reverse diffusion process."""
+
+import math
+import torch
+import torch.nn.functional as F
+from typing import Tuple
+
+
+class NoiseScheduler:
+    """
+    Manages the noise schedule for the diffusion process.
+
+    Precomputes beta, alpha, and alpha_cumprod values used in both
+    the forward (noising) and reverse (denoising) diffusion steps.
+
+    Args:
+        timesteps: Total number of diffusion steps T
+        beta_schedule: Schedule type — "linear" or "cosine"
+        beta_start: Starting beta value (used for linear schedule)
+        beta_end: Ending beta value (used for linear schedule)
+
+    Example:
+        >>> scheduler = NoiseScheduler(timesteps=1000, beta_schedule="linear")
+        >>> x0 = torch.randn(2, 1, 64, 64)
+        >>> t = torch.tensor([100, 500])
+        >>> xt, noise = scheduler.q_sample(x0, t)
+        >>> xt.shape
+        torch.Size([2, 1, 64, 64])
+    """
+
+    def __init__(
+        self,
+        timesteps: int = 1000,
+        beta_schedule: str = "linear",
+        beta_start: float = 1e-4,
+        beta_end: float = 2e-2,
+    ) -> None:
+        if beta_schedule not in {"linear", "cosine"}:
+            raise ValueError(f"Unknown beta_schedule '{beta_schedule}'. Choose 'linear' or 'cosine'.")
+
+        self.timesteps = timesteps
+        self.beta_schedule = beta_schedule
+        self.beta_start = beta_start
+        self.beta_end = beta_end
+
+        betas = (
+            self._get_betas_linear() if beta_schedule == "linear"
+            else self._get_betas_cosine()
+        )
+
+        alphas = 1.0 - betas
+        alphas_cumprod = torch.cumprod(alphas, dim=0)
+
+        self.register("betas", betas)
+        self.register("alphas", alphas)
+        self.register("alphas_cumprod", alphas_cumprod)
+        self.register("sqrt_alphas_cumprod", alphas_cumprod.sqrt())
+        self.register("sqrt_one_minus_alphas_cumprod", (1.0 - alphas_cumprod).sqrt())
+
+    def register(self, name: str, tensor: torch.Tensor) -> None:
+        """Store a precomputed tensor as an attribute."""
+        setattr(self, name, tensor)
+
+    def _get_betas_linear(self) -> torch.Tensor:
+        """Linear beta schedule from beta_start to beta_end."""
+        return torch.linspace(self.beta_start, self.beta_end, self.timesteps, dtype=torch.float64)
+
+    def _get_betas_cosine(self, s: float = 8e-3) -> torch.Tensor:
+        """
+        Cosine beta schedule (Nichol & Dhariwal, 2021).
+
+        Produces a smoother schedule that avoids too much noise at
+        the start and end of the diffusion process.
+
+        Args:
+            s: Small offset to prevent beta from being too small near t=0
+        """
+        steps = self.timesteps + 1
+        t = torch.linspace(0, self.timesteps, steps, dtype=torch.float64)
+        alphas_cumprod = torch.cos(((t / self.timesteps) + s) / (1 + s) * math.pi / 2) ** 2
+        alphas_cumprod = alphas_cumprod / alphas_cumprod[0]
+        betas = 1.0 - (alphas_cumprod[1:] / alphas_cumprod[:-1])
+        return betas.clamp(0, 0.999)
+
+    def _extract(self, tensor: torch.Tensor, t: torch.Tensor, shape: Tuple) -> torch.Tensor:
+        """Extract values at timestep t and reshape to broadcast over (B, C, H, W)."""
+        out = tensor.to(t.device)[t].float()
+        return out.reshape(t.shape[0], *((1,) * (len(shape) - 1)))
+
+    def q_sample(
+        self,
+        x0: torch.Tensor,
+        t: torch.Tensor,
+        noise: torch.Tensor | None = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Forward diffusion: add noise to clean image at timestep t.
+
+        Samples x_t ~ q(x_t | x_0) using the closed-form expression:
+            x_t = sqrt(alpha_cumprod_t) * x_0 + sqrt(1 - alpha_cumprod_t) * eps
+
+        Args:
+            x0: Clean image, shape (B, C, H, W)
+            t: Timestep indices, shape (B,)
+            noise: Optional pre-sampled noise; sampled from N(0,I) if None
+
+        Returns:
+            (x_t, noise) tuple — noisy image and the noise that was added
+        """
+        if noise is None:
+            noise = torch.randn_like(x0)
+
+        sqrt_alpha = self._extract(self.sqrt_alphas_cumprod, t, x0.shape)
+        sqrt_one_minus_alpha = self._extract(self.sqrt_one_minus_alphas_cumprod, t, x0.shape)
+
+        xt = sqrt_alpha * x0 + sqrt_one_minus_alpha * noise
+        return xt, noise
+
+    def p_sample(
+        self,
+        model: torch.nn.Module,
+        xt: torch.Tensor,
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Reverse diffusion: denoise one step from x_t to x_{t-1}.
+
+        Args:
+            model: U-Net that predicts noise given (x_t, t)
+            xt: Noisy image at timestep t, shape (B, C, H, W)
+            t: Current timestep indices, shape (B,)
+
+        Returns:
+            Denoised image x_{t-1}, shape (B, C, H, W)
+        """
+        raise NotImplementedError
+
+    def p_sample_loop(
+        self,
+        model: torch.nn.Module,
+        shape: Tuple[int, ...],
+        device: torch.device,
+    ) -> torch.Tensor:
+        """
+        Full reverse diffusion loop from pure noise to clean image.
+
+        Args:
+            model: Trained U-Net
+            shape: Output shape (B, C, H, W)
+            device: Target device
+
+        Returns:
+            Generated clean image, shape (B, C, H, W)
+        """
+        raise NotImplementedError

--- a/DENOISING_DIFFUSION/tests/test_noise_scheduler.py
+++ b/DENOISING_DIFFUSION/tests/test_noise_scheduler.py
@@ -1,0 +1,116 @@
+"""Tests for NoiseScheduler — schedule shapes, ranges, monotonicity, and q_sample."""
+
+import pytest
+import torch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from models.noise_scheduler import NoiseScheduler
+
+
+@pytest.fixture(params=["linear", "cosine"])
+def scheduler(request):
+    return NoiseScheduler(timesteps=1000, beta_schedule=request.param)
+
+
+class TestScheduleShapes:
+    def test_betas_shape(self, scheduler):
+        assert scheduler.betas.shape == (1000,)
+
+    def test_alphas_shape(self, scheduler):
+        assert scheduler.alphas.shape == (1000,)
+
+    def test_alphas_cumprod_shape(self, scheduler):
+        assert scheduler.alphas_cumprod.shape == (1000,)
+
+    def test_sqrt_alphas_cumprod_shape(self, scheduler):
+        assert scheduler.sqrt_alphas_cumprod.shape == (1000,)
+
+    def test_sqrt_one_minus_alphas_cumprod_shape(self, scheduler):
+        assert scheduler.sqrt_one_minus_alphas_cumprod.shape == (1000,)
+
+
+class TestScheduleRanges:
+    def test_betas_in_range(self, scheduler):
+        assert scheduler.betas.min() >= 0.0
+        assert scheduler.betas.max() <= 1.0
+
+    def test_alphas_in_range(self, scheduler):
+        assert scheduler.alphas.min() >= 0.0
+        assert scheduler.alphas.max() <= 1.0
+
+    def test_alphas_cumprod_in_range(self, scheduler):
+        assert scheduler.alphas_cumprod.min() >= 0.0
+        assert scheduler.alphas_cumprod.max() <= 1.0
+
+    def test_linear_beta_start(self):
+        scheduler = NoiseScheduler(timesteps=1000, beta_schedule="linear", beta_start=1e-4, beta_end=2e-2)
+        assert torch.isclose(scheduler.betas[0], torch.tensor(1e-4, dtype=torch.float64), atol=1e-6)
+
+    def test_linear_beta_end(self):
+        scheduler = NoiseScheduler(timesteps=1000, beta_schedule="linear", beta_start=1e-4, beta_end=2e-2)
+        assert torch.isclose(scheduler.betas[-1], torch.tensor(2e-2, dtype=torch.float64), atol=1e-6)
+
+
+class TestScheduleMonotonicity:
+    def test_betas_monotonically_increasing(self, scheduler):
+        # betas should increase over time (more noise added later)
+        assert (scheduler.betas[1:] >= scheduler.betas[:-1]).all()
+
+    def test_alphas_cumprod_monotonically_decreasing(self, scheduler):
+        # signal is progressively destroyed
+        assert (scheduler.alphas_cumprod[1:] <= scheduler.alphas_cumprod[:-1]).all()
+
+    def test_alphas_cumprod_starts_near_one(self, scheduler):
+        assert scheduler.alphas_cumprod[0] > 0.99
+
+    def test_alphas_cumprod_ends_near_zero(self, scheduler):
+        assert scheduler.alphas_cumprod[-1] < 0.02
+
+
+class TestQSample:
+    @pytest.fixture
+    def x0(self):
+        torch.manual_seed(0)
+        return torch.randn(4, 1, 64, 64)
+
+    def test_output_shape(self, scheduler, x0):
+        t = torch.randint(0, 1000, (4,))
+        xt, noise = scheduler.q_sample(x0, t)
+        assert xt.shape == x0.shape
+        assert noise.shape == x0.shape
+
+    def test_output_dtype(self, scheduler, x0):
+        t = torch.randint(0, 1000, (4,))
+        xt, noise = scheduler.q_sample(x0, t)
+        assert xt.dtype == torch.float32
+        assert noise.dtype == torch.float32
+
+    def test_custom_noise_used(self, scheduler, x0):
+        t = torch.randint(0, 1000, (4,))
+        noise = torch.zeros_like(x0)
+        xt, returned_noise = scheduler.q_sample(x0, t, noise=noise)
+        assert torch.equal(returned_noise, noise)
+
+    def test_t0_close_to_x0(self, x0):
+        # at t=0, very little noise should be added
+        scheduler = NoiseScheduler(timesteps=1000, beta_schedule="linear")
+        t = torch.zeros(4, dtype=torch.long)
+        noise = torch.zeros_like(x0)
+        xt, _ = scheduler.q_sample(x0, t, noise=noise)
+        assert torch.allclose(xt, x0, atol=1e-3)
+
+    def test_large_t_is_noisy(self, scheduler, x0):
+        # at t=T-1, image should be close to pure noise
+        t = torch.full((4,), 999, dtype=torch.long)
+        xt, _ = scheduler.q_sample(x0, t)
+        # correlation with original should be low
+        assert not torch.allclose(xt, x0, atol=0.1)
+
+
+class TestInvalidSchedule:
+    def test_unknown_schedule_raises(self):
+        with pytest.raises(ValueError, match="Unknown beta_schedule"):
+            NoiseScheduler(beta_schedule="invalid")


### PR DESCRIPTION
Pre-GSoC groundwork for the "Denoising Astronomical Observations 
of Protoplanetary Disks" project (GSoC 2026).

Third PR in the groundwork series, following the config system and 
model skeleton. This one is purely math — no model code touched.

Implemented the two beta schedules that control how noise is added 
during the forward diffusion process:

- Linear schedule — simple linspace from beta_start to beta_end,
  as used in the original DDPM paper (Ho et al., 2020)
- Cosine schedule — smoother alternative from Nichol & Dhariwal 2021,
  avoids adding too much noise too quickly at the start

Also precomputes all the derived tensors needed downstream 
(alphas, alphas_cumprod, sqrt variants) and implements q_sample — 
the closed-form forward diffusion step:
  x_t = sqrt(ᾱ_t) * x_0 + sqrt(1 - ᾱ_t) * ε

p_sample and p_sample_loop are still stubs — those need the U-Net 
which is coming in the next PR.

**36 unit tests** covering schedule shapes, value ranges, 
monotonicity, q_sample output, and invalid input validation.

**Files changed:**
- `src/models/noise_scheduler.py`
- `tests/test_noise_scheduler.py`