### PR TITLE
feat: Add U-Net building blocks with shape-consistency tests

### DIFF
--- a/DENOISING_DIFFUSION/src/models/blocks.py
+++ b/DENOISING_DIFFUSION/src/models/blocks.py
@@ -1,0 +1,132 @@
+"""Building blocks for the U-Net backbone."""
+
+import math
+import torch
+import torch.nn as nn
+
+
+class SinusoidalTimeEmbedding(nn.Module):
+    """
+    Sinusoidal positional embedding for diffusion timestep conditioning.
+
+    Encodes scalar timestep t into a fixed-size vector that gets injected
+    into each ResidualBlock of the U-Net.
+
+    Args:
+        dim: Embedding dimension (should match U-Net base channels * 4)
+    """
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            t: Timestep tensor, shape (B,)
+
+        Returns:
+            Embedding tensor, shape (B, dim)
+        """
+        half = self.dim // 2
+        freqs = torch.exp(
+            -math.log(10000) * torch.arange(half, device=t.device) / (half - 1)
+        ).float()
+        args = t.float()[:, None] * freqs[None]
+        return torch.cat([args.sin(), args.cos()], dim=-1)
+
+
+class ResidualBlock(nn.Module):
+    """
+    Residual block with GroupNorm, SiLU activation, and time conditioning.
+
+    Used in both encoder and decoder of the U-Net. Injects the timestep
+    embedding via a linear projection added to the hidden features.
+
+    Args:
+        in_channels: Number of input channels
+        out_channels: Number of output channels
+        time_emb_dim: Dimension of the time embedding vector
+        dropout: Dropout probability
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        time_emb_dim: int,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        self.block1 = nn.Sequential(
+            nn.GroupNorm(8, in_channels),
+            nn.SiLU(),
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+        )
+        self.time_proj = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(time_emb_dim, out_channels),
+        )
+        self.block2 = nn.Sequential(
+            nn.GroupNorm(8, out_channels),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1),
+        )
+        self.skip = (
+            nn.Conv2d(in_channels, out_channels, kernel_size=1)
+            if in_channels != out_channels
+            else nn.Identity()
+        )
+
+    def forward(self, x: torch.Tensor, time_emb: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Input feature map, shape (B, in_channels, H, W)
+            time_emb: Time embedding, shape (B, time_emb_dim)
+
+        Returns:
+            Output feature map, shape (B, out_channels, H, W)
+        """
+        h = self.block1(x)
+        h = h + self.time_proj(time_emb)[:, :, None, None]
+        h = self.block2(h)
+        return h + self.skip(x)
+
+
+class AttentionBlock(nn.Module):
+    """
+    Self-attention block for capturing global context.
+
+    Applied at deeper U-Net levels where spatial resolution is low.
+    Uses multi-head self-attention with GroupNorm and residual connection.
+
+    Args:
+        channels: Number of input/output channels
+        num_heads: Number of attention heads
+    """
+
+    def __init__(self, channels: int, num_heads: int = 4) -> None:
+        super().__init__()
+        self.channels = channels
+        self.num_heads = num_heads
+        self.norm = nn.GroupNorm(8, channels)
+        self.attn = nn.MultiheadAttention(channels, num_heads, batch_first=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Input feature map, shape (B, channels, H, W)
+
+        Returns:
+            Output feature map, shape (B, channels, H, W)
+        """
+        B, C, H, W = x.shape
+        h = self.norm(x)
+        h = h.reshape(B, C, H * W).permute(0, 2, 1)
+        h, _ = self.attn(h, h, h)
+        h = h.permute(0, 2, 1).reshape(B, C, H, W)
+        return x + h

--- a/DENOISING_DIFFUSION/tests/test_blocks.py
+++ b/DENOISING_DIFFUSION/tests/test_blocks.py
@@ -1,0 +1,114 @@
+"""Shape-consistency tests for U-Net building blocks."""
+
+import pytest
+import torch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from models.blocks import ResidualBlock, AttentionBlock, SinusoidalTimeEmbedding
+
+
+class TestSinusoidalTimeEmbedding:
+    def test_output_shape(self):
+        emb = SinusoidalTimeEmbedding(dim=256)
+        t = torch.randint(0, 1000, (4,))
+        out = emb(t)
+        assert out.shape == (4, 256)
+
+    def test_output_shape_batch_1(self):
+        emb = SinusoidalTimeEmbedding(dim=128)
+        t = torch.tensor([42])
+        out = emb(t)
+        assert out.shape == (1, 128)
+
+    def test_different_timesteps_differ(self):
+        emb = SinusoidalTimeEmbedding(dim=64)
+        t1 = torch.tensor([0])
+        t2 = torch.tensor([500])
+        assert not torch.allclose(emb(t1), emb(t2))
+
+    def test_same_timestep_same_output(self):
+        emb = SinusoidalTimeEmbedding(dim=64)
+        t = torch.tensor([100])
+        assert torch.allclose(emb(t), emb(t))
+
+    def test_output_dtype_float32(self):
+        emb = SinusoidalTimeEmbedding(dim=64)
+        t = torch.randint(0, 1000, (2,))
+        assert emb(t).dtype == torch.float32
+
+
+class TestResidualBlock:
+    @pytest.fixture
+    def block_same(self):
+        return ResidualBlock(in_channels=64, out_channels=64, time_emb_dim=256)
+
+    @pytest.fixture
+    def block_proj(self):
+        return ResidualBlock(in_channels=64, out_channels=128, time_emb_dim=256)
+
+    def test_output_shape_same_channels(self, block_same):
+        x = torch.randn(2, 64, 32, 32)
+        t = torch.randn(2, 256)
+        out = block_same(x, t)
+        assert out.shape == (2, 64, 32, 32)
+
+    def test_output_shape_channel_projection(self, block_proj):
+        x = torch.randn(2, 64, 32, 32)
+        t = torch.randn(2, 256)
+        out = block_proj(x, t)
+        assert out.shape == (2, 128, 32, 32)
+
+    def test_spatial_dims_preserved(self, block_same):
+        for h, w in [(16, 16), (32, 32), (64, 64)]:
+            x = torch.randn(2, 64, h, w)
+            t = torch.randn(2, 256)
+            out = block_same(x, t)
+            assert out.shape == (2, 64, h, w)
+
+    def test_skip_identity_when_same_channels(self, block_same):
+        assert isinstance(block_same.skip, torch.nn.Identity)
+
+    def test_skip_conv_when_different_channels(self, block_proj):
+        assert isinstance(block_proj.skip, torch.nn.Conv2d)
+
+    def test_is_nn_module(self, block_same):
+        assert isinstance(block_same, torch.nn.Module)
+
+    def test_output_not_equal_to_input(self, block_same):
+        x = torch.randn(2, 64, 32, 32)
+        t = torch.randn(2, 256)
+        out = block_same(x, t)
+        assert not torch.allclose(out, x)
+
+
+class TestAttentionBlock:
+    @pytest.fixture
+    def block(self):
+        return AttentionBlock(channels=64, num_heads=4)
+
+    def test_output_shape(self, block):
+        x = torch.randn(2, 64, 16, 16)
+        out = block(x)
+        assert out.shape == (2, 64, 16, 16)
+
+    def test_spatial_dims_preserved(self, block):
+        for h, w in [(8, 8), (16, 16), (32, 32)]:
+            x = torch.randn(2, 64, h, w)
+            assert block(x).shape == (2, 64, h, w)
+
+    def test_batch_size_preserved(self, block):
+        for b in [1, 4, 8]:
+            x = torch.randn(b, 64, 16, 16)
+            assert block(x).shape[0] == b
+
+    def test_residual_connection(self, block):
+        # zero input should not produce zero output due to residual
+        x = torch.zeros(2, 64, 16, 16)
+        out = block(x)
+        assert out.shape == x.shape
+
+    def test_is_nn_module(self, block):
+        assert isinstance(block, torch.nn.Module)


### PR DESCRIPTION
## Summary

Part of pre-GSoC groundwork for the EXXA DDPM denoising pipeline.

Adds the three core reusable blocks that the U-Net encoder/decoder will be built from.

## Changes

- `SinusoidalTimeEmbedding` — log-spaced sin/cos frequency embeddings for diffusion timestep conditioning
- `ResidualBlock` — GroupNorm + SiLU + Conv2d with time projection injection and 1×1 skip when channels differ
- `AttentionBlock` — GroupNorm + MultiheadAttention over flattened spatial dims with residual connection

## Tests

17 shape-consistency tests in `tests/test_blocks.py` covering:

- Output shapes and spatial preservation
- Variable batch sizes
- Both skip connection paths (identity and 1×1 projection)
- dtype correctness

All 17 pass.

## Next

Next PR will assemble these blocks into the full U-Net encoder/decoder stack.
