### PR TITLE
feat: Add training loop skeleton with logging hooks and checkpoint save/load

### DIFF
--- a/DENOISING_DIFFUSION/src/training/__init__.py
+++ b/DENOISING_DIFFUSION/src/training/__init__.py
@@ -1,0 +1,3 @@
+from .trainer import Trainer
+
+__all__ = ["Trainer"]

--- a/DENOISING_DIFFUSION/src/training/trainer.py
+++ b/DENOISING_DIFFUSION/src/training/trainer.py
@@ -1,0 +1,83 @@
+"""Minimal training loop with logging hooks and checkpoint save/load."""
+
+import os
+from typing import Callable, Optional
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+
+class Trainer:
+    """
+    Model-agnostic training loop for the DDPM denoising pipeline.
+
+    Expects the model to accept a batch and return a scalar loss tensor
+    via a `training_loss(batch) -> Tensor` method.
+
+    Args:
+        model: nn.Module with a `training_loss(batch) -> Tensor` method
+        optimizer: PyTorch optimizer
+        device: torch device
+        log_fn: Optional callback called with (epoch, step, loss) after each step
+        checkpoint_dir: Directory for saving/loading checkpoints
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        log_fn: Optional[Callable[[int, int, float], None]] = None,
+        checkpoint_dir: str = "checkpoints",
+    ) -> None:
+        self.model = model.to(device)
+        self.optimizer = optimizer
+        self.device = device
+        self.log_fn = log_fn
+        self.checkpoint_dir = checkpoint_dir
+        self.epoch = 0
+
+    def train_one_epoch(self, dataloader: DataLoader) -> float:
+        """Run one full epoch. Returns mean loss over all steps."""
+        self.model.train()
+        total_loss = 0.0
+
+        for step, batch in enumerate(dataloader):
+            if isinstance(batch, (list, tuple)):
+                batch = [x.to(self.device) if isinstance(x, torch.Tensor) else x for x in batch]
+            else:
+                batch = batch.to(self.device)
+
+            self.optimizer.zero_grad()
+            loss = self.model.training_loss(batch)
+            loss.backward()
+            self.optimizer.step()
+
+            total_loss += loss.item()
+            if self.log_fn is not None:
+                self.log_fn(self.epoch, step, loss.item())
+
+        self.epoch += 1
+        return total_loss / max(len(dataloader), 1)
+
+    def save_checkpoint(self, tag: str = "latest") -> str:
+        """Save model + optimizer state. Returns path to saved file."""
+        os.makedirs(self.checkpoint_dir, exist_ok=True)
+        path = os.path.join(self.checkpoint_dir, f"ckpt_{tag}.pt")
+        torch.save(
+            {
+                "epoch": self.epoch,
+                "model_state": self.model.state_dict(),
+                "optimizer_state": self.optimizer.state_dict(),
+            },
+            path,
+        )
+        return path
+
+    def load_checkpoint(self, path: str) -> None:
+        """Load model + optimizer state from a checkpoint file."""
+        ckpt = torch.load(path, map_location=self.device)
+        self.model.load_state_dict(ckpt["model_state"])
+        self.optimizer.load_state_dict(ckpt["optimizer_state"])
+        self.epoch = ckpt["epoch"]

--- a/DENOISING_DIFFUSION/tests/test_trainer.py
+++ b/DENOISING_DIFFUSION/tests/test_trainer.py
@@ -1,0 +1,203 @@
+"""Tests for Trainer: instantiation, train step, loss descent, checkpoint round-trip."""
+
+import os
+import tempfile
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from src.training.trainer import Trainer
+
+
+# ---------------------------------------------------------------------------
+# Minimal toy model: accepts a batch tensor, returns MSE toward zero
+# ---------------------------------------------------------------------------
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(16, 16)
+
+    def training_loss(self, batch):
+        x = batch[0] if isinstance(batch, (list, tuple)) else batch
+        return (self.linear(x) ** 2).mean()
+
+
+def make_dataloader(n=32, feat=16, batch_size=8):
+    data = torch.randn(n, feat)
+    return DataLoader(TensorDataset(data), batch_size=batch_size)
+
+
+def make_trainer(tmpdir=None, log_fn=None):
+    model = ToyModel()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    device = torch.device("cpu")
+    return Trainer(
+        model=model,
+        optimizer=optimizer,
+        device=device,
+        log_fn=log_fn,
+        checkpoint_dir=tmpdir or "checkpoints",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instantiation
+# ---------------------------------------------------------------------------
+
+def test_trainer_instantiates():
+    trainer = make_trainer()
+    assert trainer.epoch == 0
+
+
+def test_trainer_model_on_device():
+    trainer = make_trainer()
+    for p in trainer.model.parameters():
+        assert p.device == torch.device("cpu")
+
+
+def test_trainer_default_epoch_zero():
+    trainer = make_trainer()
+    assert trainer.epoch == 0
+
+
+# ---------------------------------------------------------------------------
+# train_one_epoch
+# ---------------------------------------------------------------------------
+
+def test_train_one_epoch_returns_float():
+    trainer = make_trainer()
+    loss = trainer.train_one_epoch(make_dataloader())
+    assert isinstance(loss, float)
+
+
+def test_train_one_epoch_loss_positive():
+    trainer = make_trainer()
+    loss = trainer.train_one_epoch(make_dataloader())
+    assert loss > 0
+
+
+def test_train_one_epoch_increments_epoch():
+    trainer = make_trainer()
+    trainer.train_one_epoch(make_dataloader())
+    assert trainer.epoch == 1
+
+
+def test_train_multiple_epochs_increments():
+    trainer = make_trainer()
+    for _ in range(3):
+        trainer.train_one_epoch(make_dataloader())
+    assert trainer.epoch == 3
+
+
+def test_loss_decreases_over_epochs():
+    trainer = make_trainer()
+    dl = make_dataloader(n=64)
+    losses = [trainer.train_one_epoch(dl) for _ in range(10)]
+    assert losses[-1] < losses[0]
+
+
+# ---------------------------------------------------------------------------
+# Logging hook
+# ---------------------------------------------------------------------------
+
+def test_log_fn_called():
+    calls = []
+    trainer = make_trainer(log_fn=lambda epoch, step, loss: calls.append((epoch, step, loss)))
+    trainer.train_one_epoch(make_dataloader(n=32, batch_size=8))
+    assert len(calls) == 4  # 32 samples / batch_size 8 = 4 steps
+
+
+def test_log_fn_receives_correct_epoch():
+    calls = []
+    trainer = make_trainer(log_fn=lambda epoch, step, loss: calls.append(epoch))
+    trainer.train_one_epoch(make_dataloader())
+    assert all(e == 0 for e in calls)
+
+
+def test_log_fn_loss_is_float():
+    calls = []
+    trainer = make_trainer(log_fn=lambda epoch, step, loss: calls.append(loss))
+    trainer.train_one_epoch(make_dataloader())
+    assert all(isinstance(l, float) for l in calls)
+
+
+def test_no_log_fn_runs_without_error():
+    trainer = make_trainer(log_fn=None)
+    trainer.train_one_epoch(make_dataloader())
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint save / load
+# ---------------------------------------------------------------------------
+
+def test_save_checkpoint_creates_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trainer = make_trainer(tmpdir=tmpdir)
+        path = trainer.save_checkpoint("test")
+        assert os.path.exists(path)
+
+
+def test_save_checkpoint_returns_correct_path():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trainer = make_trainer(tmpdir=tmpdir)
+        path = trainer.save_checkpoint("v1")
+        assert path.endswith("ckpt_v1.pt")
+
+
+def test_load_checkpoint_restores_epoch():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trainer = make_trainer(tmpdir=tmpdir)
+        trainer.train_one_epoch(make_dataloader())
+        path = trainer.save_checkpoint()
+
+        trainer2 = make_trainer(tmpdir=tmpdir)
+        trainer2.load_checkpoint(path)
+        assert trainer2.epoch == 1
+
+
+def test_load_checkpoint_restores_model_weights():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trainer = make_trainer(tmpdir=tmpdir)
+        trainer.train_one_epoch(make_dataloader())
+        path = trainer.save_checkpoint()
+
+        trainer2 = make_trainer(tmpdir=tmpdir)
+        trainer2.load_checkpoint(path)
+
+        for p1, p2 in zip(trainer.model.parameters(), trainer2.model.parameters()):
+            assert torch.allclose(p1, p2)
+
+
+def test_checkpoint_round_trip_loss_consistent():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trainer = make_trainer(tmpdir=tmpdir)
+        dl = make_dataloader()
+        trainer.train_one_epoch(dl)
+        path = trainer.save_checkpoint()
+
+        trainer2 = make_trainer(tmpdir=tmpdir)
+        trainer2.load_checkpoint(path)
+
+        trainer.model.eval()
+        trainer2.model.eval()
+        x = torch.randn(8, 16)
+        with torch.no_grad():
+            out1 = trainer.model.linear(x)
+            out2 = trainer2.model.linear(x)
+        assert torch.allclose(out1, out2)
+
+
+def test_multiple_checkpoints_independent():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trainer = make_trainer(tmpdir=tmpdir)
+        dl = make_dataloader()
+        trainer.train_one_epoch(dl)
+        path1 = trainer.save_checkpoint("epoch1")
+        trainer.train_one_epoch(dl)
+        path2 = trainer.save_checkpoint("epoch2")
+        assert path1 != path2
+        assert os.path.exists(path1)
+        assert os.path.exists(path2)


### PR DESCRIPTION
Part of pre-GSoC groundwork for the EXXA DDPM denoising pipeline.

Adds a minimal, model-agnostic `Trainer` class that drives the training loop.

## Changes

- `src/training/trainer.py` — `Trainer` class with:
  - `train_one_epoch()` — dataloader iteration, forward pass, loss, optimizer step
  - `log_fn` hook — called with `(epoch, step, loss)` after each step
  - `save_checkpoint()` / `load_checkpoint()` — full state dict round-trip
- `src/training/__init__.py` — exports `Trainer`

## Design

`Trainer` is model-agnostic — it expects any `nn.Module` with a `training_loss(batch) -> Tensor` method. This means it works today with the toy model in tests and will plug directly into `DDPM` once implemented.

## Tests

18 tests in `tests/test_trainer.py` covering:

- Instantiation and device placement
- `train_one_epoch` return type, loss positivity, epoch counter
- Loss descent over multiple epochs on a toy synthetic batch
- Logging hook call count and argument types
- Checkpoint save/load restoring epoch, model weights, and inference consistency

All 18 pass.