### PR TITLE
feat: Add inference pipeline skeleton with preprocess, run, and checkpoint loading

### DIFF
--- a/DENOISING_DIFFUSION/src/inference/__init__.py
+++ b/DENOISING_DIFFUSION/src/inference/__init__.py
@@ -1,0 +1,3 @@
+from .inferencer import Inferencer
+
+__all__ = ["Inferencer"]

--- a/DENOISING_DIFFUSION/src/inference/inferencer.py
+++ b/DENOISING_DIFFUSION/src/inference/inferencer.py
@@ -1,0 +1,125 @@
+"""Inference pipeline: load checkpoint, preprocess, run model, postprocess."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+class Inferencer:
+    """
+    Inference pipeline for the EXXA denoising models.
+
+    Handles preprocessing (numpy → normalized tensor), model execution,
+    and postprocessing (tensor → numpy). Compatible with any nn.Module
+    that implements either `sample(x)` or a standard `forward(x)`.
+
+    Args:
+        model: Loaded nn.Module in eval mode
+        device: torch device to run inference on
+    """
+
+    def __init__(self, model: nn.Module, device: torch.device) -> None:
+        self.model = model.to(device).eval()
+        self.device = device
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        model: nn.Module,
+        checkpoint_path: str,
+        device: Optional[torch.device] = None,
+    ) -> "Inferencer":
+        """
+        Load model weights from a checkpoint and return an Inferencer.
+
+        Args:
+            model: Uninitialised nn.Module with the correct architecture
+            checkpoint_path: Path to a .pt checkpoint saved by Trainer
+            device: Target device (defaults to cpu)
+        """
+        if device is None:
+            device = torch.device("cpu")
+        ckpt = torch.load(checkpoint_path, map_location=device)
+        model.load_state_dict(ckpt["model_state"])
+        return cls(model, device)
+
+    # ------------------------------------------------------------------
+    # Pre / post processing
+    # ------------------------------------------------------------------
+
+    def preprocess(self, image: np.ndarray) -> torch.Tensor:
+        """
+        Convert a numpy image to a normalised tensor ready for the model.
+
+        Applies min-max normalisation to [0, 1] then maps to [-1, 1].
+        Adds a batch dimension and a channel dimension if missing.
+
+        Args:
+            image: numpy array of shape (H, W), (C, H, W), or (B, C, H, W)
+
+        Returns:
+            Float tensor of shape (B, C, H, W) in [-1, 1]
+        """
+        x = image.astype(np.float32)
+
+        vmin, vmax = x.min(), x.max()
+        if vmax - vmin > 1e-8:
+            x = (x - vmin) / (vmax - vmin)
+
+        # map [0, 1] -> [-1, 1]
+        x = x * 2.0 - 1.0
+
+        t = torch.from_numpy(x)
+
+        if t.ndim == 2:          # (H, W) -> (1, 1, H, W)
+            t = t.unsqueeze(0).unsqueeze(0)
+        elif t.ndim == 3:        # (C, H, W) -> (1, C, H, W)
+            t = t.unsqueeze(0)
+        # ndim == 4: already (B, C, H, W)
+
+        return t.to(self.device)
+
+    def postprocess(self, tensor: torch.Tensor) -> np.ndarray:
+        """
+        Convert model output tensor back to a numpy image in [0, 1].
+
+        Args:
+            tensor: Float tensor of shape (B, C, H, W) in [-1, 1]
+
+        Returns:
+            numpy array of shape (B, C, H, W) clamped to [0, 1]
+        """
+        out = torch.clamp((tensor + 1.0) / 2.0, 0.0, 1.0)
+        return out.detach().cpu().numpy()
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def run(self, image: np.ndarray) -> np.ndarray:
+        """
+        End-to-end inference: preprocess → model → postprocess.
+
+        Calls `model.sample(x)` if available, otherwise `model(x)`.
+
+        Args:
+            image: Raw numpy image (H, W), (C, H, W), or (B, C, H, W)
+
+        Returns:
+            Denoised numpy array of shape (B, C, H, W) in [0, 1]
+        """
+        x = self.preprocess(image)
+        with torch.no_grad():
+            if hasattr(self.model, "sample") and callable(self.model.sample):
+                out = self.model.sample(x)
+            else:
+                out = self.model(x)
+        return self.postprocess(out)

--- a/DENOISING_DIFFUSION/tests/test_inferencer.py
+++ b/DENOISING_DIFFUSION/tests/test_inferencer.py
@@ -1,0 +1,220 @@
+"""Tests for Inferencer: preprocess, postprocess, run, and from_checkpoint."""
+
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from src.inference.inferencer import Inferencer
+from src.training.trainer import Trainer
+
+
+# ---------------------------------------------------------------------------
+# Toy models
+# ---------------------------------------------------------------------------
+
+class PassthroughModel(nn.Module):
+    """Returns input unchanged — used to test shape preservation."""
+    def forward(self, x):
+        return x
+
+
+class SampleModel(nn.Module):
+    """Has a sample() method — tests that Inferencer prefers sample() over forward()."""
+    def forward(self, x):
+        return torch.zeros_like(x)          # forward returns zeros
+
+    def sample(self, x):
+        return torch.ones_like(x)           # sample returns ones
+
+
+class LinearModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, kernel_size=1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+    def training_loss(self, batch):
+        x = batch[0] if isinstance(batch, (list, tuple)) else batch
+        return (self.conv(x) ** 2).mean()
+
+
+def make_inferencer(model=None):
+    model = model or PassthroughModel()
+    return Inferencer(model, torch.device("cpu"))
+
+
+# ---------------------------------------------------------------------------
+# Instantiation
+# ---------------------------------------------------------------------------
+
+def test_inferencer_instantiates():
+    inf = make_inferencer()
+    assert inf is not None
+
+
+def test_model_set_to_eval():
+    inf = make_inferencer()
+    assert not inf.model.training
+
+
+def test_device_stored():
+    inf = make_inferencer()
+    assert inf.device == torch.device("cpu")
+
+
+# ---------------------------------------------------------------------------
+# from_checkpoint
+# ---------------------------------------------------------------------------
+
+def test_from_checkpoint_loads_weights():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = LinearModel()
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        trainer = Trainer(model, optimizer, torch.device("cpu"), checkpoint_dir=tmpdir)
+
+        from torch.utils.data import DataLoader, TensorDataset
+        dl = DataLoader(TensorDataset(torch.randn(16, 1, 8, 8)), batch_size=4)
+        trainer.train_one_epoch(dl)
+        path = trainer.save_checkpoint()
+
+        inf = Inferencer.from_checkpoint(LinearModel(), path)
+        for p1, p2 in zip(trainer.model.parameters(), inf.model.parameters()):
+            assert torch.allclose(p1, p2)
+
+
+def test_from_checkpoint_returns_inferencer():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = LinearModel()
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        trainer = Trainer(model, optimizer, torch.device("cpu"), checkpoint_dir=tmpdir)
+
+        from torch.utils.data import DataLoader, TensorDataset
+        dl = DataLoader(TensorDataset(torch.randn(8, 1, 8, 8)), batch_size=4)
+        trainer.train_one_epoch(dl)
+        path = trainer.save_checkpoint()
+
+        inf = Inferencer.from_checkpoint(LinearModel(), path)
+        assert isinstance(inf, Inferencer)
+
+
+# ---------------------------------------------------------------------------
+# preprocess
+# ---------------------------------------------------------------------------
+
+def test_preprocess_hw_adds_batch_and_channel():
+    inf = make_inferencer()
+    img = np.random.rand(64, 64).astype(np.float32)
+    t = inf.preprocess(img)
+    assert t.shape == (1, 1, 64, 64)
+
+
+def test_preprocess_chw_adds_batch():
+    inf = make_inferencer()
+    img = np.random.rand(1, 64, 64).astype(np.float32)
+    t = inf.preprocess(img)
+    assert t.shape == (1, 1, 64, 64)
+
+
+def test_preprocess_bchw_unchanged():
+    inf = make_inferencer()
+    img = np.random.rand(2, 1, 64, 64).astype(np.float32)
+    t = inf.preprocess(img)
+    assert t.shape == (2, 1, 64, 64)
+
+
+def test_preprocess_range_minus1_to_1():
+    inf = make_inferencer()
+    img = np.random.rand(32, 32).astype(np.float32)
+    t = inf.preprocess(img)
+    assert t.min().item() >= -1.0 - 1e-5
+    assert t.max().item() <= 1.0 + 1e-5
+
+
+def test_preprocess_returns_tensor():
+    inf = make_inferencer()
+    t = inf.preprocess(np.random.rand(16, 16))
+    assert isinstance(t, torch.Tensor)
+
+
+def test_preprocess_constant_image_no_nan():
+    inf = make_inferencer()
+    img = np.ones((32, 32), dtype=np.float32)
+    t = inf.preprocess(img)
+    assert not torch.isnan(t).any()
+
+
+# ---------------------------------------------------------------------------
+# postprocess
+# ---------------------------------------------------------------------------
+
+def test_postprocess_clamps_to_0_1():
+    inf = make_inferencer()
+    t = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0])
+    out = inf.postprocess(t.reshape(1, 1, 1, 5))
+    assert out.min() >= 0.0
+    assert out.max() <= 1.0
+
+
+def test_postprocess_returns_numpy():
+    inf = make_inferencer()
+    t = torch.zeros(1, 1, 8, 8)
+    out = inf.postprocess(t)
+    assert isinstance(out, np.ndarray)
+
+
+def test_postprocess_shape_preserved():
+    inf = make_inferencer()
+    t = torch.randn(2, 1, 16, 16)
+    out = inf.postprocess(t)
+    assert out.shape == (2, 1, 16, 16)
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+def test_run_output_shape_hw():
+    inf = make_inferencer()
+    img = np.random.rand(32, 32).astype(np.float32)
+    out = inf.run(img)
+    assert out.shape == (1, 1, 32, 32)
+
+
+def test_run_output_range_0_1():
+    inf = make_inferencer()
+    img = np.random.rand(32, 32).astype(np.float32)
+    out = inf.run(img)
+    assert out.min() >= 0.0
+    assert out.max() <= 1.0
+
+
+def test_run_prefers_sample_over_forward():
+    inf = make_inferencer(SampleModel())
+    img = np.random.rand(16, 16).astype(np.float32)
+    out = inf.run(img)
+    # sample() returns ones -> postprocess maps 1.0 to 1.0
+    assert np.allclose(out, 1.0)
+
+
+def test_run_falls_back_to_forward():
+    class ZeroForward(nn.Module):
+        def forward(self, x):
+            return torch.zeros_like(x)
+
+    inf = make_inferencer(ZeroForward())
+    img = np.random.rand(16, 16).astype(np.float32)
+    out = inf.run(img)
+    # forward returns zeros -> postprocess maps 0.0 to 0.5
+    assert np.allclose(out, 0.5)
+
+
+def test_run_no_grad_no_error():
+    inf = make_inferencer()
+    img = np.random.rand(16, 16).astype(np.float32)
+    out = inf.run(img)
+    assert out is not None


### PR DESCRIPTION
## Summary

Inference pipeline skeleton for the EXXA DDPM denoising workflow.

Adds `Inferencer` — a thin wrapper that handles everything between a raw
numpy image and a denoised numpy output.

## What it does

- `from_checkpoint()` — reconstructs a model from a Trainer checkpoint
- `preprocess()` — normalises raw input to `[-1, 1]`, handles `(H,W)` / `(C,H,W)` / `(B,C,H,W)` automatically
- `run()` — calls `model.sample(x)` if available, falls back to `model(x)`
- `postprocess()` — maps output back to `[0, 1]` and returns numpy

## Design note

The `sample()` vs `forward()` dispatch means this plugs directly into
`DDPM.sample()` once implemented with zero changes to the inference code.

## Tests

19 tests covering instantiation, checkpoint loading, preprocessing edge
cases (constant image, all input shapes), postprocess clamping, and both
dispatch paths. All pass.
