### PR TITLE
feat: Add CI workflow and contribution guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "DENOISING_DIFFUSION/**"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "DENOISING_DIFFUSION/**"
+      - ".github/workflows/ci.yml"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: DENOISING_DIFFUSION
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install scikit-image numpy scipy pytest flake8
+
+      - name: Lint
+        run: |
+          flake8 src/models/ src/training/ src/inference/ src/utils/ \
+            tests/test_blocks.py tests/test_trainer.py tests/test_inferencer.py tests/test_metrics.py \
+            --max-line-length=100 --ignore=E203,W503
+
+      - name: Test
+        run: pytest tests/ -v

--- a/DENOISING_DIFFUSION/CONTRIBUTING.md
+++ b/DENOISING_DIFFUSION/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to DENOISING_DIFFUSION
+
+## Setup
+
+```bash
+git clone https://github.com/ML4SCI/EXXA.git
+cd EXXA/DENOISING_DIFFUSION
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install scikit-image numpy scipy pytest flake8
+```
+
+## Running Tests
+
+```bash
+# from DENOISING_DIFFUSION/
+pytest tests/ -v
+```
+
+Run a single test file:
+
+```bash
+pytest tests/test_metrics.py -v
+```
+
+## Lint
+
+```bash
+flake8 src/ tests/ --max-line-length=100 --ignore=E203,W503
+```
+
+## Branch Naming
+
+| Type | Pattern | Example |
+|---|---|---|
+| Feature | `feat/<short-name>` | `feat/unet-blocks` |
+| Bug fix | `fix/<short-name>` | `fix/ssim-bchw` |
+| Docs | `docs/<short-name>` | `docs/training-guide` |
+
+Always branch from `upstream/main`, not from another feature branch.
+
+## PR Checklist
+
+- [ ] Branch is from `main`, not another feature branch
+- [ ] Only files relevant to this PR are staged
+- [ ] All existing tests pass (`pytest tests/ -v`)
+- [ ] New code has corresponding tests
+- [ ] Lint passes (`flake8 src/ tests/`)
+- [ ] PR description explains what changed and why


### PR DESCRIPTION
## Summary

Adds CI workflow and contribution guide for the DENOISING_DIFFUSION pipeline.

## Changes

- `.github/workflows/ci.yml` — triggers on push/PR to `main` for changes under `DENOISING_DIFFUSION/`:
  - Python 3.10
  - Installs PyTorch (CPU), scikit-image, numpy, scipy, pytest, flake8
  - Lints `src/models/`, `src/training/`, `src/inference/`, `src/utils/`
  - Runs `pytest tests/`

- `DENOISING_DIFFUSION/CONTRIBUTING.md`:
  - Dev environment setup
  - Running tests and lint
  - Branch naming conventions
  - PR checklist